### PR TITLE
CMake update 3/3: provide install target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -494,6 +494,9 @@ install(DIRECTORY include/chibi
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/include/chibi/install.h
     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/chibi)
 
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/chibi-scheme.pc
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
+
 add_library(chibi::libchibi-scheme ALIAS libchibi-scheme)
 
 install(TARGETS libchibi-scheme chibi-scheme

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -181,6 +181,10 @@ function(add_compiled_library cfile)
         LIBRARY_OUTPUT_DIRECTORY ${libdir}
         LIBRARY_OUTPUT_NAME ${basename}
         PREFIX "")
+
+    file(RELATIVE_PATH installsubdir ${CMAKE_CURRENT_BINARY_DIR}/lib ${libdir})
+    install(TARGETS ${libname}
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}/chibi/${installsubdir})
 endfunction()
 
 if(BUILD_SHARED_LIBS)
@@ -493,6 +497,55 @@ install(FILES ${CMAKE_CURRENT_BINARY_DIR}/include/chibi/install.h
 
 add_library(chibi::libchibi-scheme ALIAS libchibi-scheme)
 
-install(TARGETS libchibi-scheme
+install(TARGETS libchibi-scheme chibi-scheme
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+
+install(FILES
+    tools/chibi-ffi
+    tools/chibi-doc
+    tools/snow-chibi
+    tools/snow-chibi.scm
+    DESTINATION ${CMAKE_INSTALL_BINDIR})
+
+install(FILES
+    doc/chibi-scheme.1
+    doc/chibi-ffi.1
+    doc/chibi-doc.1
+    DESTINATION ${CMAKE_INSTALL_MANDIR}/man1)
+
+if(BUILD_SHARED_LIBS)
+    install(FILES
+        ${CMAKE_CURRENT_BINARY_DIR}/chibi.img
+        ${CMAKE_CURRENT_BINARY_DIR}/red.img
+        ${CMAKE_CURRENT_BINARY_DIR}/snow.img
+        DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/chibi)
+endif()
+
+install(DIRECTORY
+    lib/
+    DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/chibi
+    PATTERN "*win32" EXCLUDE
+    PATTERN "*test.sld" EXCLUDE
+    PATTERN "*.c" EXCLUDE
+    PATTERN "*.stub" EXCLUDE)
+
+# This is to revert the above exclusion pattern
+install(FILES lib/chibi/test.sld
+    DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/chibi/chibi)
+
+if(WIN32)
+    install(DIRECTORY
+        lib/
+        DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/chibi
+        FILES_MATCHING
+        PATTERN "*win32/*.scm"
+        PATTERN "*win32/*.sld")
+endif()
+
+install(FILES
+    ${CMAKE_CURRENT_BINARY_DIR}/.chibi.meta
+    ${CMAKE_CURRENT_BINARY_DIR}/.scheme.meta
+    ${CMAKE_CURRENT_BINARY_DIR}/.srfi.meta
+    DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/chibi)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -436,6 +436,48 @@ add_test(NAME "foreign-typeid"
     COMMAND test-foreign-typeid
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 
+
+#
+# Image, pkgconfig and meta file generation
+#
+
+add_custom_target(chibi-images
+    COMMAND chibi-scheme -I ${CMAKE_CURRENT_BINARY_DIR}/lib
+        -mchibi.repl -d ${CMAKE_CURRENT_BINARY_DIR}/chibi.img
+    COMMAND chibi-scheme -I ${CMAKE_CURRENT_BINARY_DIR}/lib
+        -xscheme.red -mchibi.repl -d ${CMAKE_CURRENT_BINARY_DIR}/red.img
+    COMMAND chibi-scheme -I ${CMAKE_CURRENT_BINARY_DIR}/lib
+        -mchibi.snow.commands -mchibi.snow.interface -mchibi.snow.package -mchibi.snow.utils
+        -d ${CMAKE_CURRENT_BINARY_DIR}/snow.img
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+
+configure_file(contrib/chibi-scheme.pc.cmake.in chibi-scheme.pc @ONLY)
+
+function(generate_package_list libdir output)
+    add_custom_command(OUTPUT ${output}
+        COMMAND
+        ${CMAKE_COMMAND}
+        -DEXEC=$<TARGET_FILE:chibi-scheme>
+        -DLIBDIR=${libdir}
+        -DGENMETA=tools/generate-install-meta.scm
+        -DVERSION=${CMAKE_PROJECT_VERSION}
+        -DOUT=${CMAKE_CURRENT_BINARY_DIR}/${output}
+        -P contrib/chibi-generate-install-meta-helper.cmake
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+        DEPENDS chibi-scheme)
+endfunction()
+
+generate_package_list(lib/chibi .chibi.meta)
+generate_package_list(lib/scheme .scheme.meta)
+generate_package_list(lib/srfi .srfi.meta)
+
+add_custom_target(meta-lists
+    DEPENDS
+    ${CMAKE_CURRENT_BINARY_DIR}/.chibi.meta
+    ${CMAKE_CURRENT_BINARY_DIR}/.scheme.meta
+    ${CMAKE_CURRENT_BINARY_DIR}/.srfi.meta)
+
+
 #
 # Installation
 #

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,7 @@ project(chibi-scheme LANGUAGES C VERSION ${version}
 include(CheckIncludeFile)
 include(CheckSymbolExists)
 include(GNUInstallDirs)
+include(CMakePackageConfigHelpers)
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
@@ -499,7 +500,8 @@ install(FILES ${CMAKE_CURRENT_BINARY_DIR}/chibi-scheme.pc
 
 add_library(chibi::libchibi-scheme ALIAS libchibi-scheme)
 
-install(TARGETS libchibi-scheme chibi-scheme
+install(TARGETS libchibi-scheme libchibi-common chibi-scheme
+    EXPORT chibi-scheme-targets
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
@@ -551,3 +553,17 @@ install(FILES
     ${CMAKE_CURRENT_BINARY_DIR}/.scheme.meta
     ${CMAKE_CURRENT_BINARY_DIR}/.srfi.meta
     DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/chibi)
+
+install(EXPORT chibi-scheme-targets
+    FILE chibi-scheme-targets.cmake
+    NAMESPACE chibi::
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/chibi)
+
+write_basic_package_version_file(chibi-scheme-config-version.cmake
+    VERSION ${CMAKE_PROJECT_VERSION}
+    COMPATIBILITY ExactVersion)
+
+install(FILES
+    contrib/chibi-scheme-config.cmake
+    ${CMAKE_CURRENT_BINARY_DIR}/chibi-scheme-config-version.cmake
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/chibi)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -488,7 +488,6 @@ add_custom_target(meta-lists
 
 install(DIRECTORY include/chibi
     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
-    USE_SOURCE_PERMISSIONS
     PATTERN "sexp-*.[hc]" EXCLUDE
     PATTERN "*.h.in" EXCLUDE)
 

--- a/contrib/chibi-generate-install-meta-helper.cmake
+++ b/contrib/chibi-generate-install-meta-helper.cmake
@@ -1,0 +1,10 @@
+
+execute_process(
+    COMMAND find ${LIBDIR} -name "*.sld"
+    COMMAND ${EXEC} ${GENMETA} ${VERSION}
+    OUTPUT_FILE ${OUT}
+    RESULT_VARIABLE error)
+
+if(error)
+    message(FATAL_ERROR "${error}")
+endif()

--- a/contrib/chibi-scheme-config.cmake
+++ b/contrib/chibi-scheme-config.cmake
@@ -1,0 +1,2 @@
+
+include(${CMAKE_CURRENT_LIST_DIR}/chibi-scheme-targets.cmake)

--- a/contrib/chibi-scheme.pc.cmake.in
+++ b/contrib/chibi-scheme.pc.cmake.in
@@ -1,0 +1,14 @@
+# pkg-config
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=@CMAKE_INSTALL_FULL_BINDIR@
+libdir=@CMAKE_INSTALL_FULL_LIBDIR@
+includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
+version=@CMAKE_PROJECT_VERSION@
+
+Name: chibi-scheme
+URL: http://synthcode.com/scheme/chibi/
+Description: Minimal Scheme Implementation for use as an Extension Language
+Version: ${version}
+Libs: -L${libdir} -lchibi-scheme
+Libs.private: -dl -lm
+Cflags: -I${includedir}


### PR DESCRIPTION
Follow-up PR for the [`CMake` modernization](https://github.com/ashinn/chibi-scheme/pull/755) and [lifting of platform restrictions](https://github.com/lubgr/chibi-scheme/pull/1) that fleshes out `install` targets. In short, this enables the following:
```
mkdir build && cd build
cmake -G Ninja path/to/chibi-source
ninja
ninja chibi-images meta-lists # not built by default
ninja install
```
will build shared libraries, the three image dumps and package metadata, and install it into `/usr/local`. The install path can be changed with `cmake -D CMAKE_INSTALL_PREFIX=/my/custom/path`, which will in turn show up in the `install.h` search paths.

There is some additional plumbing to ensure that the installation works well with `CMake` projects using chibi. Given a `CMake`-configured chibi installation under a standard Unix path like `/usr` or `/usr/local` (other paths work when passing `cmake -D CMAKE_PREFIX_PATH=/non/standard`), the following sets up an embedding application:
```
add_executable(my_great_app main.cpp)

find_package(chibi-scheme 0.10.0 REQUIRED)

target_link_libraries(my_great_app
  PRIVATE
  chibi::libchibi-scheme)
```
All necessary linker and preprocessor flags will automatically be configured, and it works with a shared or a static library build/installation.

As an aside, I compared the current `make install` result to the result from the `CMake`-configured installation (by means of `tree`), which raised the following questions:

- The Makefile seems to install many `*-test.sld` files. Is that intended?
- The srfi-18 threads shared library is installed twice, under `srfi/18` and `chibi/`, why is that?
- `lib/scheme/mapping/hash.sld` and `lib/srfi/160/uvector.scm` are currently not installed, is this intended?

Also:

- Are image dumps supposed to work with static chibi builds? I haven't really investigated, but it seems that a static chibi executable doesn't generate any images.

Lastly, the following PRs might make sense if that's desired from your point of view.

- Update the docs (happy to do this)
- CI integration

However, I appreciate that maintaining two full build systems is not fun, in particular when one of them is `CMake` :) 
